### PR TITLE
Backport patch to fix build with cmake 4

### DIFF
--- a/rpm/0001-Update-minimum-cmake-version-from-3.0-to-3.6.patch
+++ b/rpm/0001-Update-minimum-cmake-version-from-3.0-to-3.6.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Peter Toft <peter.toft@dirac.com>
+Date: Thu, 3 Apr 2025 15:42:29 +0200
+Subject: [PATCH] Update minimum cmake version from 3.0 to 3.6
+
+* With cmake 4 [1] the support for cmake 3.5 or lower was cut [2]
+* cmake 4 was deployed on github.com around 2025-04-02
+  which started to break many things e.g. ogg
+* cmake 3.5 was released in 2016 [3] and many versions in the
+  3.30 range has warned about the deprecation
+
+[1] https://cmake.org/download/#latest
+[2] https://cmake.org/cmake/help/v4.0/release/4.0.html
+[3] https://www.kitware.com/cmake-3-5-0-available-for-download/
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fe20f2da9489e308a5d819482df9cf65d6badea0..9bb85c3136967f7b86fe099dc1df64e40d8111c3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.6)
+ project(libogg)
+ 
+ # Required modules

--- a/rpm/libogg.spec
+++ b/rpm/libogg.spec
@@ -3,8 +3,9 @@ Summary:    The Ogg bitstream file format library
 Version:    1.3.5
 Release:    1
 License:    BSD
-URL:        https://www.xiph.org/
+URL:        https://github.com/sailfishos/libogg
 Source0:    %{name}-%{version}.tar.bz2
+Patch1:     0001-Update-minimum-cmake-version-from-3.0-to-3.6.patch
 BuildRequires: cmake
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
@@ -35,31 +36,24 @@ Documentation for developing applications with libogg
 
 
 %prep
-%autosetup -n %{name}-%{version}/%{name}
+%autosetup -p1 -n %{name}-%{version}/%{name}
 
 %build
-mkdir -p build
-pushd build
-%cmake -DBUILD_SHARED_LIBS=1 ..
-%make_build
-popd
+%cmake -DBUILD_SHARED_LIBS=1
+%cmake_build
 
 %install
-pushd build
-%make_install
-popd
+%cmake_install
 
 %post -p /sbin/ldconfig
 
 %postun -p /sbin/ldconfig
 
 %files
-%defattr(-,root,root,-)
 %license COPYING
 %{_libdir}/libogg.so.*
 
 %files devel
-%defattr(-,root,root,-)
 %doc AUTHORS CHANGES README.md
 %dir %{_includedir}/ogg
 %{_includedir}/ogg/ogg.h
@@ -70,5 +64,4 @@ popd
 %{_libdir}/pkgconfig/ogg.pc
 
 %files doc
-%defattr(-,root,root,-)
 %{_docdir}/%{name}


### PR DESCRIPTION
Use packaging URL in spec. Use cmake macros.
Remove not needed defattr from spec.